### PR TITLE
Set MIX_ENV to test environment so we don't recompile dependencies in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  
+env:
+  MIX_ENV: test
 
 jobs:
   build:


### PR DESCRIPTION
We were compiling everything twice since some of the `mix` commands use different default environments.