### PR TITLE
Turn autocomplete off on weight and reps inputs

### DIFF
--- a/lib/we_lift_web/live/workout_live/edit.ex
+++ b/lib/we_lift_web/live/workout_live/edit.ex
@@ -27,8 +27,8 @@ defmodule WeLiftWeb.WorkoutLive.Edit do
 
       <.input field={{f, :workout_id}} type="hidden" value={@workout.id} />
       <.input field={{f, :exercise_id}} type="select" options={@exercises} required />
-      <.input field={{f, :weight_in_lbs}} label="Weight (lbs.)" required />
-      <.input field={{f, :reps}} label="Reps" required />
+      <.input field={{f, :weight_in_lbs}} label="Weight (lbs.)" required autocomplete="off" />
+      <.input field={{f, :reps}} label="Reps" required autocomplete="off" />
 
       <:actions>
         <.button phx-disable-with="Adding...">Finish Set</.button>

--- a/lib/we_lift_web/live/workout_live/edit.ex
+++ b/lib/we_lift_web/live/workout_live/edit.ex
@@ -26,9 +26,9 @@ defmodule WeLiftWeb.WorkoutLive.Edit do
       </div>
 
       <.input field={{f, :workout_id}} type="hidden" value={@workout.id} />
-      <.input field={{f, :exercise_id}} type="select" options={@exercises} required />
-      <.input field={{f, :weight_in_lbs}} label="Weight (lbs.)" required autocomplete="off" />
-      <.input field={{f, :reps}} label="Reps" required autocomplete="off" />
+      <.input field={{f, :exercise_id}} type="select" options={@exercises} />
+      <.input field={{f, :weight_in_lbs}} label="Weight (lbs.)" autocomplete="off" />
+      <.input field={{f, :reps}} label="Reps" autocomplete="off" />
 
       <:actions>
         <.button phx-disable-with="Adding...">Finish Set</.button>


### PR DESCRIPTION
Also removes `required` attribute from form inputs since that functionality is handled by the Ecto changeset.