### PR TITLE
Adjust landing page for very small width screens

### DIFF
--- a/lib/we_lift_web/controllers/page_html.ex
+++ b/lib/we_lift_web/controllers/page_html.ex
@@ -32,7 +32,10 @@ defmodule WeLiftWeb.PageHTML do
         if(assigns.hero, do: "lg:h-[680px] h-fit", else: "lg:h-[580px] h-fit")
       )
       |> assign(:title_font_size, if(assigns.hero, do: "sm:text-6xl text-4xl", else: "text-4xl"))
-      |> assign(:description_font_size, if(assigns.hero, do: "sm:text-2xl text-xl", else: "text-xl"))
+      |> assign(
+        :description_font_size,
+        if(assigns.hero, do: "sm:text-2xl text-xl", else: "text-xl")
+      )
 
     ~H"""
     <div class={"flex #{@height_style} flex-row p-8 #{@color_style}"}>

--- a/lib/we_lift_web/controllers/page_html.ex
+++ b/lib/we_lift_web/controllers/page_html.ex
@@ -29,7 +29,7 @@ defmodule WeLiftWeb.PageHTML do
       |> assign(:text_order_style, if(assigns.reverse, do: "lg:order-2 order-1", else: "order-1"))
       |> assign(
         :height_style,
-        if(assigns.hero, do: "lg:h-[680px] h-[780px]", else: "lg:h-[580px] h-[730px]")
+        if(assigns.hero, do: "lg:h-[680px] h-fit", else: "lg:h-[580px] h-fit")
       )
       |> assign(:title_font_size, if(assigns.hero, do: "sm:text-6xl text-4xl", else: "text-4xl"))
       |> assign(:description_font_size, if(assigns.hero, do: "sm:text-2xl text-xl", else: "text-xl"))

--- a/lib/we_lift_web/controllers/page_html.ex
+++ b/lib/we_lift_web/controllers/page_html.ex
@@ -53,7 +53,7 @@ defmodule WeLiftWeb.PageHTML do
             <% end %>
           </div>
         </div>
-        <div class={"flex lg:w-1/2 justify-center #{@image_order_style}"}>
+        <div class={"flex lg:w-1/2 lg:p-0 pb-8 justify-center #{@image_order_style}"}>
           <div class="flex flex-col justify-center max-w-xl">
             <img class={"rounded-2xl #{@border_style}"} src={@image} />
           </div>

--- a/lib/we_lift_web/controllers/page_html.ex
+++ b/lib/we_lift_web/controllers/page_html.ex
@@ -31,8 +31,8 @@ defmodule WeLiftWeb.PageHTML do
         :height_style,
         if(assigns.hero, do: "lg:h-[680px] h-[780px]", else: "lg:h-[580px] h-[730px]")
       )
-      |> assign(:title_font_size, if(assigns.hero, do: "text-6xl", else: "text-4xl"))
-      |> assign(:description_font_size, if(assigns.hero, do: "text-2xl", else: "text-xl"))
+      |> assign(:title_font_size, if(assigns.hero, do: "sm:text-6xl text-4xl", else: "text-4xl"))
+      |> assign(:description_font_size, if(assigns.hero, do: "sm:text-2xl text-xl", else: "text-xl"))
 
     ~H"""
     <div class={"flex #{@height_style} flex-row p-8 #{@color_style}"}>

--- a/lib/we_lift_web/controllers/page_html/home.html.heex
+++ b/lib/we_lift_web/controllers/page_html/home.html.heex
@@ -1,10 +1,10 @@
-<section class="container mx-auto p-8 flex flex-row">
-  <a href={~p"/"} class="text-4xl font-bold">WeLift</a>
+<section class="container mx-auto sm:p-6 p-4 flex flex-row">
+  <a href={~p"/"} class="flex text-4xl font-bold self-end">WeLift</a>
   <div class="flex grow justify-end">
-    <.button class="text-xl py-2 px-4 mx-1" phx-click={JS.navigate(~p"/users/register")}>
+    <.button class="sm:text-xl text-l py-2 px-4 mx-1" phx-click={JS.navigate(~p"/users/register")}>
       Sign Up
     </.button>
-    <.button class="text-xl py-2 px-4 mx-1" phx-click={JS.navigate(~p"/users/log_in")}>
+    <.button class="sm:text-xl text-l py-2 px-4 mx-1" phx-click={JS.navigate(~p"/users/log_in")}>
       Log in
     </.button>
   </div>


### PR DESCRIPTION
These fixes are primarily targeted to mobile devices:

- Decrease font sizes of hero element text for very small width screens
- Make feature component height fit content on small width screens
- Add padding below the image on small width screens
- Adjust padding and font sizes in landing page header